### PR TITLE
Fix unlimited guesses and `NameError` when reporting answer

### DIFF
--- a/wordle.ipynb
+++ b/wordle.ipynb
@@ -28,7 +28,7 @@
     "    if status == \"win\":\n",
     "        print(\"Congratulations, you guessed it right!\")\n",
     "    else:\n",
-    "        print(f\"Sorry, you lost. The right word was {word}.\")\n",
+    "        print(f\"Sorry, you lost. The right word was {answer_word}.\")\n",
     "    \n",
     "    turn_number=0\n",
     "    return \n",
@@ -42,7 +42,7 @@
     "\n",
     "def guess_word(guess_word):\n",
     "    global turn_number\n",
-    "    turn_number += 0\n",
+    "    turn_number += 1\n",
     "    if len(guess_word) != 5:\n",
     "        return wrong_guess_length(guess_word)\n",
     "    if turn_number > GAME_LENGTH:\n",
@@ -111,7 +111,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "_ _ _ d _ \n"
+      "_ * _ * _ \n"
      ]
     }
    ],


### PR DESCRIPTION
Fix >6 guesses being allowed
Fix `NameError` when reporting correct answer after failing to guess word